### PR TITLE
activated pagination for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 build/
 .gradle/
 .jmix
+
+.DS_Store
+node_modules/

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -35,5 +35,4 @@ asciidoc:
     # end cuba frontend
     minimal-idea-version: '2020.2'
     idea-download-site: 'https://www.jetbrains.com/idea/download/'
-    jmix-nightly: 'https://plugins.jetbrains.com/plugins/jmix_nightly/list'
-    jmix-plugin-site: 'https://plugins.jetbrains.com/plugin/14340-jmix/versions'
+    page-pagination: true

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -35,4 +35,6 @@ asciidoc:
     # end cuba frontend
     minimal-idea-version: '2020.2'
     idea-download-site: 'https://www.jetbrains.com/idea/download/'
+    jmix-nightly: 'https://plugins.jetbrains.com/plugins/jmix_nightly/list'
+    jmix-plugin-site: 'https://plugins.jetbrains.com/plugin/14340-jmix/versions'
     page-pagination: true


### PR DESCRIPTION
## Overview

This PR activates pagination for the main documentation. Antora has this functionality as a out-of-the-box feature, until now it is just hidden behind a feature flag:

```
asciidoc:
  attributes:
    page-pagination: true
```

## Screenshots

<img width="1343" alt="Bildschirmfoto 2021-03-02 um 07 19 11" src="https://user-images.githubusercontent.com/817400/109606909-9cd3cf80-7b27-11eb-8b4e-46a63b16d2b5.png">
<img width="1343" alt="Bildschirmfoto 2021-03-02 um 07 19 00" src="https://user-images.githubusercontent.com/817400/109606919-a0675680-7b27-11eb-8b5d-76747bb74e8b.png">
<img width="1343" alt="Bildschirmfoto 2021-03-02 um 07 18 55" src="https://user-images.githubusercontent.com/817400/109606922-a1988380-7b27-11eb-82fd-84a57986acaf.png">

## More Information

Antora 2.3 announcement: https://docs.antora.org/antora/2.3/whats-new/#smarter-pagination