### PR TITLE
REST API - File Upload & Download

### DIFF
--- a/content/modules/rest/pages/files-api.adoc
+++ b/content/modules/rest/pages/files-api.adoc
@@ -1,4 +1,4 @@
-= Manage Files
+= Files API
 
 This API uses the xref:files:index.adoc[Files mechanism] provided by Jmix and exposes it through the REST API to let client applications upload and download files to/from a Jmix application.
 
@@ -11,7 +11,7 @@ There are two different ways of transferring the data:
 1. Using `multipart/form-data`
 2. Using different content types with the body containing the binary data
 
-Depending on the use-case either of those two options might be a better fit. In both situations, the API returns `201 - Created` to indicate that the file was successfully stored.
+Depending on the use case either of those two options might be a better fit. In both situations, the API returns `201 - Created` to indicate that the file was successfully stored.
 
 === Using Multipart/form-data
 

--- a/content/modules/rest/pages/generic-functionality.adoc
+++ b/content/modules/rest/pages/generic-functionality.adoc
@@ -2,20 +2,7 @@
 
 The Generic REST API comes with different built-in functionalities to interact with a Jmix application:
 
-* <<File Interactions,File Interactions>> Uploading and Downloading xref:files:index.adoc[Files] to the application.
-
 * <<Metadata,Metadata>> Endpoints for introspection of various information, like data-model descriptions, information about the current user and their permission or localized messages.
-
-
-== File Interactions
-
-=== Downloading Files
-
-TIP: https://doc.cuba-platform.com/restapi-7.1/#rest_api_v2_ex_file_download
-
-=== Uploading Files
-
-TIP: https://doc.cuba-platform.com/restapi-7.1/#rest_api_v2_ex_file_upload
 
 
 == Metadata

--- a/content/modules/rest/pages/managing-files.adoc
+++ b/content/modules/rest/pages/managing-files.adoc
@@ -17,7 +17,7 @@ Depending on the use-case either of those two options might be a better fit. In 
 
 When using a standard browser form to submit the file to the Jmix application, the preferred way is to use the first option, as browsers by default use the Content-Type `multipart/form-data` in this case. The form data that contains the file binary needs to be named `file` so that Jmix takes this part as the file content.
 
-In this example you can see a `multipart/form-data` request, that upload the file `cat.jpg` in its raw HTTP form:
+In this example you can see a `multipart/form-data` request, that uploads the file `cat.jpg` in its raw HTTP form:
 
 [source, http request]
 .Upload File as Multipart/form-data Request
@@ -45,25 +45,23 @@ Content-Type: image/jpeg
   "size": 85862
 }
 ----
-<1> The `fileReference` contains the reference or ID for downloading / referencing the file later.
+<1> The `fileReference` contains the reference for later use.
 
 In case you want to control the file name under which the file is stored, you can set the URL parameter `name` like this:
 `POST http://localhost:8080/rest/files?name=dog.jpg`. In this case, Jmix will pick up the filename from the parameter and not consider the `Content-Disposition`.
-
-TIP: When using an HTML form it is not directly possible to set the `Authorization` header. For this reason, the Generic REST API alternatively allows attaching the access token as a URL parameter. You can find more information about authenticate via URL parameter in the security section xref:security.adoc#_authenticate_via_url_parameter[Authenticate via URL Parameter].
 
 [NOTE]
 ====
 When using an HTML `<form src="" />` tag to upload a file it is _not_ directly possible to set the `Authorization` header.
 
-The Generic REST API therefore also to xref:security.adoc#_authenticate_via_url_parameter[authenticate via URL Parameter] as an alternative.
+The Generic REST API therefore also allows to xref:security.adoc#_authenticate_via_url_parameter[authenticate via URL Parameter] as an alternative.
 ====
 
 === Using Direct Upload
 
-It is also possible to upload a file without using the `multipart/form-data` content type. Instead, you can use the content type of the file directly. Then, the body of the HTTP request directly contains the binary information.
+It is also possible to upload a file without using the `multipart/form-data` content type. Instead, you can use the content type of the file directly. The body of the HTTP request contains the binary file content directly in this case. You need to provide the URL parameter `name` to indicate which filename to use for the file.
 
-You need to provide the URL parameter `name` to indicate which filename to use for the file. In this example you can see how to use the Direct Request to upload a file:
+In this example you can see how to use the Direct Request to upload a file:
 
 [source, http request]
 .Upload File as Direct Request
@@ -90,7 +88,7 @@ Content-Type: image/jpeg // <2>
 
 == Downloading Files
 
-Files that are already stored in your Jmix application, can also be downloaded or displayed. For this you should use the Downloading Files endpoint: `/files?fileRef=:fileRef` via HTTP `GET`. The API returns `200 - OK` if the file was found together with the file binary content as part of the HTTP body.
+Files that are already uploaded in your Jmix application, can also be downloaded or displayed. For this you should use the Downloading Files endpoint: `/files?fileRef=:fileRef` via HTTP `GET`. The API returns `200 - OK` if the file was found together with the file binary content as part of the HTTP body. Otherwise `404 - Not Found` is returned.
 
 In the following example the previously uploaded file is downloaded via the API:
 
@@ -111,23 +109,23 @@ Content-Type: image/jpeg // <2>
 
 > ./cat-via-direct-content-type.jpg // <3>
 ----
-<1> The `Content-Disposition` contains the filename as well as information on how to treat the file while downloading (`inline` or `attachment`).
-<2> The `Content-Type` returns the content type of the file.
+<1> The `Content-Disposition` Header contains the filename as well as information on how to handle the file after downloading (`inline` or `attachment`).
+<2> The `Content-Type` Header contains the content type of the file.
 <3> `> ./cat-via-direct-content-type.jpg` stands for the binary data of the file (_the actual binary content is not displayed here_).
 
 [NOTE]
 ====
 When using an HTML link or rendering an image through the `<img src="" />` tag to a file it is _not_ directly possible to set the `Authorization` header.
 
-The Generic REST API therefore also to xref:security.adoc#_authenticate_via_url_parameter[authenticate via URL Parameter] as an alternative.
+The Generic REST API therefore also allows to xref:security.adoc#_authenticate_via_url_parameter[authenticate via URL Parameter] as an alternative.
 ====
 
 
 == Referencing Files from Entities
 
-You can link files to entities after the file has been uploaded in a previous request.
+You can link files to entities after the file has been stored in the Jmix application.
 
-First, you need to upload the file in a separate request as described in <<_uploading_files, Uploading Files>>. In the response, a file reference like `fs://2021/03/12/2266c97c-cf23-c202-481d-04d972e185b4.jpg?name=cat-via-direct-request.jpg` is mentioned. This reference you can use in subsequent requests for creating / updating entities and link them to the file.
+First, you need to upload the file as described in <<_uploading_files, Uploading Files>>. In the response of the upload, a file reference like `fs://2021/03/12/2266c97c-cf23-c202-481d-04d972e185b4.jpg?name=cat-via-direct-request.jpg` is returned. You can use this reference when creating / updating entities and link them to the file.
 
 In the following example, the `Product` entity uses a file reference to store a product image.
 

--- a/content/modules/rest/pages/managing-files.adoc
+++ b/content/modules/rest/pages/managing-files.adoc
@@ -1,0 +1,128 @@
+= Manage Files
+
+This API uses the xref:files:index.adoc[Files mechanism] provided by Jmix and exposes it through the REST API to let client applications upload and download files to / from a Jmix application.
+
+== Uploading Files
+
+The Upload Files API endpoint `/files` used with a `POST` HTTP method allows you to transfer a file to the Jmix application.
+
+There are two different ways of transferring the data:
+
+1. Using `multipart/form-data`
+2. Using different content types with the body containing the binary data
+
+Depending on the use-case either of those two options might be a better fit. In both situations the API returns `201 - Created` to indicate that the file was successfully stored.
+
+=== Using Multipart/form-data
+
+When using a standard browser form to submit the file to the Jmix application, the preferred way is to use the first option, as browsers by default use the Content-Type `multipart/form-data` in this case. The form data that contains the file binary needs to be named `file` so that Jmix takes this part as the file content.
+
+In this example you can see a `multipart/form-data` request, that upload the file `cat.jpg` in its raw HTTP form:
+
+[source, http request]
+.Upload File as Multipart/form-data Request
+----
+POST http://localhost:8080/rest/files
+Content-Type: multipart/form-data; boundary=WebAppBoundary // <1>
+
+--WebAppBoundary
+Content-Disposition: form-data; name="file"; filename="cat.jpg" // <2>
+Content-Type: image/jpeg
+
+< ./cat.jpg // <3>
+--WebAppBoundary--
+----
+<1> The `Content-Type` of the HTTP request is `multipart/form-data`
+<2> The `Content-Disposition` part with the name `file` expresses the file to upload. The filename there as well.
+<3> `< ./cat.jpg` stands for the binary data of the file (_the actual binary content is not displayed here_).
+
+[source, json]
+.Response: 201 - Created
+----
+{
+  "fileReference": "fs://2021/03/12/a3b6011d-9040-151e-7d17-f7ccdf75d72f.jpg?name=cat.jpg", // <1>
+  "name": "cat.jpg",
+  "size": 85862
+}
+----
+<1> The `fileReference` contains the reference or ID for downloading / referencing the file later.
+
+In case you want to control the file name under which the file is stored, you can set the URL parameter `name` like this:
+`POST http://localhost:8080/rest/files?name=dog.jpg`. In this case, Jmix will pick up the filename from the parameter and not take the `Content-Disposition` into consideration.
+
+TIP: When using an HTML form it is not directly possible to set the `Authorization` header. For this reason, the Generic REST API alternatively allows to attach the access token as a URL parameter. You can find more information about authenticate via URL parameter in the security section xref:security.adoc#_authenticate_via_url_parameter[Authenticate via URL Parameter].
+
+[NOTE]
+====
+When using an HTML `<form src="" />` tag to upload a file it is _not_ directly possible to set the `Authorization` header.
+
+The Generic REST API therefore also to xref:security.adoc#_authenticate_via_url_parameter[authenticate via URL Parameter] as an alternative.
+====
+
+=== Using Direct Upload
+
+It is also possible to upload a file without using the `multipart/form-data` content type. Instead, you can use the content type of the file directly. Then, the body of the HTTP request directly contains the binary information.
+
+You need to provide the URL parameter `name` to indicate which filename to use for the file. In this example you can see how to use the Direct Request to upload a file:
+
+[source, http request]
+.Upload File as Direct Request
+----
+POST http://localhost:8080/rest/files?name=cat-via-direct-request.jpg // <1>
+Content-Type: image/jpeg // <2>
+
+< ./cat.jpg // <3>
+----
+<1> The `name` URL parameter provides the filename to store.
+<2> The `Content-Type` is the actual content type of the file.
+<3> `< ./cat.jpg` stands for the binary data of the file (_the actual binary content is not displayed here_).
+
+[source, json]
+.Response: 201 - Created
+----
+{
+  "fileReference": "fs://2021/03/12/2266c97c-cf23-c202-481d-04d972e185b4.jpg?name=cat-via-direct-request.jpg",
+  "name": "cat-via-direct-request.jpg",
+  "size": 85862
+}
+----
+
+
+== Downloading Files
+
+Files that are already stored in your Jmix application, can also be downloaded or displayed. For this you should use the Downloading Files endpoint: `/files?fileRef=:fileRef` via HTTP `GET`. The API returns `200 - OK` if the file was found together with the file binary content as part of the HTTP body.
+
+In the following example the previously uploaded file is downloaded via the API:
+
+[source, http request]
+.Download File Request
+----
+GET http://localhost:8080/rest
+            /files
+            ?fileRef=fs://2021/03/12/2266c97c-cf23-c202-481d-04d972e185b4.jpg?name=cat-via-direct-request.jpg // <1>
+----
+<1> `fs://2021/03/12/2266c97c-cf23-c202-481d-04d972e185b4.jpg?name=cat-via-direct-request.jpg` identifies the file by its reference.
+
+[source, http request]
+.Response: 200 - OK
+----
+Content-Disposition: inline; filename="cat-via-direct-content-type.jpg" // <1>
+Content-Type: image/jpeg // <2>
+
+> ./cat-via-direct-content-type.jpg // <3>
+----
+<1> The `Content-Disposition` contains the filename as well as information on how to treat the file while downloading (`inline` or `attachment`).
+<2> The `Content-Type` returns the content type of the file.
+<3> `> ./cat-via-direct-content-type.jpg` stands for the binary data of the file (_the actual binary content is not displayed here_).
+
+[NOTE]
+====
+When using an HTML link or rendering an image through the `<img src="" />` tag to a file it is _not_ directly possible to set the `Authorization` header.
+
+The Generic REST API therefore also to xref:security.adoc#_authenticate_via_url_parameter[authenticate via URL Parameter] as an alternative.
+====
+
+
+== Referencing Files to an Entity
+
+TIP: new

--- a/content/modules/rest/pages/managing-files.adoc
+++ b/content/modules/rest/pages/managing-files.adoc
@@ -123,6 +123,54 @@ The Generic REST API therefore also to xref:security.adoc#_authenticate_via_url_
 ====
 
 
-== Referencing Files to an Entity
+== Referencing Files from Entities
 
-TIP: new
+You can link files to entities after the file has been uploaded in a previous request.
+
+First, you need to upload the file in a separate request as described in <<_uploading_files, Uploading Files>>. In the response, a file reference like `fs://2021/03/12/2266c97c-cf23-c202-481d-04d972e185b4.jpg?name=cat-via-direct-request.jpg` is mentioned. This reference you can use in subsequent requests for creating / updating entities and link them to the file.
+
+In the following example, the `Product` entity uses a file reference to store a product image.
+
+[source,java]
+.Product.java
+----
+@JmixEntity
+@Table(name = "RSTEX11_PRODUCT")
+@Entity(name = "rstex11_Product")
+public class Product {
+
+    @PropertyDatatype("fileRef")
+    @Column(name = "IMAGE")
+    private FileRef image;
+
+    //...
+}
+----
+
+When creating a Product via the Create Entities API, you need to pass in the previously received file reference as the value of the `image` attribute:
+
+[source, http request]
+.Create Product with File Reference Request
+----
+POST http://localhost:8080/rest
+            /entities
+            /rstex11_Product
+            ?responseFetchPlan=_local
+
+{
+  "name": "Product with Image",
+  "price":100,
+  "image": "fs://2021/03/13/f623e8ab-524e-51ed-1a9f-b1c1369239e3.jpg?name=cat.jpg"
+}
+----
+
+[source,json]
+.Response: 201 - Created
+----
+{
+  "id": "ea6f1b3c-0e74-c90b-b009-9f58ac964034",
+  "image": "fs://2021/03/13/f623e8ab-524e-51ed-1a9f-b1c1369239e3.jpg?name=cat.jpg",
+  "price": 100.00,
+  "name": "Product with Image"
+}
+----

--- a/content/modules/rest/pages/managing-files.adoc
+++ b/content/modules/rest/pages/managing-files.adoc
@@ -1,6 +1,6 @@
 = Manage Files
 
-This API uses the xref:files:index.adoc[Files mechanism] provided by Jmix and exposes it through the REST API to let client applications upload and download files to / from a Jmix application.
+This API uses the xref:files:index.adoc[Files mechanism] provided by Jmix and exposes it through the REST API to let client applications upload and download files to/from a Jmix application.
 
 == Uploading Files
 
@@ -11,7 +11,7 @@ There are two different ways of transferring the data:
 1. Using `multipart/form-data`
 2. Using different content types with the body containing the binary data
 
-Depending on the use-case either of those two options might be a better fit. In both situations the API returns `201 - Created` to indicate that the file was successfully stored.
+Depending on the use-case either of those two options might be a better fit. In both situations, the API returns `201 - Created` to indicate that the file was successfully stored.
 
 === Using Multipart/form-data
 
@@ -48,9 +48,9 @@ Content-Type: image/jpeg
 <1> The `fileReference` contains the reference or ID for downloading / referencing the file later.
 
 In case you want to control the file name under which the file is stored, you can set the URL parameter `name` like this:
-`POST http://localhost:8080/rest/files?name=dog.jpg`. In this case, Jmix will pick up the filename from the parameter and not take the `Content-Disposition` into consideration.
+`POST http://localhost:8080/rest/files?name=dog.jpg`. In this case, Jmix will pick up the filename from the parameter and not consider the `Content-Disposition`.
 
-TIP: When using an HTML form it is not directly possible to set the `Authorization` header. For this reason, the Generic REST API alternatively allows to attach the access token as a URL parameter. You can find more information about authenticate via URL parameter in the security section xref:security.adoc#_authenticate_via_url_parameter[Authenticate via URL Parameter].
+TIP: When using an HTML form it is not directly possible to set the `Authorization` header. For this reason, the Generic REST API alternatively allows attaching the access token as a URL parameter. You can find more information about authenticate via URL parameter in the security section xref:security.adoc#_authenticate_via_url_parameter[Authenticate via URL Parameter].
 
 [NOTE]
 ====

--- a/content/modules/rest/pages/managing-files.adoc
+++ b/content/modules/rest/pages/managing-files.adoc
@@ -40,12 +40,12 @@ Content-Type: image/jpeg
 .Response: 201 - Created
 ----
 {
-  "fileReference": "fs://2021/03/12/a3b6011d-9040-151e-7d17-f7ccdf75d72f.jpg?name=cat.jpg", // <1>
+  "fileRef": "fs://2021/03/12/a3b6011d-9040-151e-7d17-f7ccdf75d72f.jpg?name=cat.jpg", // <1>
   "name": "cat.jpg",
   "size": 85862
 }
 ----
-<1> The `fileReference` contains the reference for later use.
+<1> The `fileRef` contains the reference for later use.
 
 In case you want to control the file name under which the file is stored, you can set the URL parameter `name` like this:
 `POST http://localhost:8080/rest/files?name=dog.jpg`. In this case, Jmix will pick up the filename from the parameter and not consider the `Content-Disposition`.
@@ -79,7 +79,7 @@ Content-Type: image/jpeg // <2>
 .Response: 201 - Created
 ----
 {
-  "fileReference": "fs://2021/03/12/2266c97c-cf23-c202-481d-04d972e185b4.jpg?name=cat-via-direct-request.jpg",
+  "fileRef": "fs://2021/03/12/2266c97c-cf23-c202-481d-04d972e185b4.jpg?name=cat-via-direct-request.jpg",
   "name": "cat-via-direct-request.jpg",
   "size": 85862
 }

--- a/content/modules/rest/pages/security.adoc
+++ b/content/modules/rest/pages/security.adoc
@@ -2,6 +2,10 @@
 
 == Authentication
 
+=== Authenticate via Header
+
+=== Authenticate via URL Parameter
+
 == Role Definition
 
 == OAuth Token

--- a/content/modules/rest/partials/nav.adoc
+++ b/content/modules/rest/partials/nav.adoc
@@ -6,7 +6,7 @@
 *** xref:rest:entities-api/update-entities.adoc[]
 *** xref:rest:entities-api/delete-entities.adoc[]
 ** xref:rest:generic-functionality.adoc[]
-** xref:rest:managing-files.adoc[]
+** xref:rest:files-api.adoc[]
 ** xref:rest:business-logic.adoc[]
 ** xref:rest:security.adoc[]
 ** xref:rest:api-docs.adoc[]

--- a/content/modules/rest/partials/nav.adoc
+++ b/content/modules/rest/partials/nav.adoc
@@ -6,6 +6,7 @@
 *** xref:rest:entities-api/update-entities.adoc[]
 *** xref:rest:entities-api/delete-entities.adoc[]
 ** xref:rest:generic-functionality.adoc[]
+** xref:rest:managing-files.adoc[]
 ** xref:rest:business-logic.adoc[]
 ** xref:rest:security.adoc[]
 ** xref:rest:api-docs.adoc[]


### PR DESCRIPTION
This PR contains:

* File Uploading
* Different approaches to upload files (multipart/form-data vs. regular content-type)
* File Downloading
* extraction of "Manage Files" to a dedicated section within the REST API docs
* new example on how to reference a file to an entity

✓ Grammarly

What has been not taken over is the HTML example from the CUBA docs (https://doc.cuba-platform.com/restapi-7.1/#rest_api_v2_ex_file_upload) on uploading a file via a form.