### PR TITLE
REST API: API documentation

### DIFF
--- a/content/modules/rest/pages/api-docs.adoc
+++ b/content/modules/rest/pages/api-docs.adoc
@@ -1,5 +1,36 @@
 = API Documentation
 
+The generic REST API provides automatically generated API documentation through Swagger 2.0.
+
+You can use the API documentation to visualize, test, or generate a client code for the REST API. There are various tools that allow to use this documentation to provide those capabilities like:
+
+* https://swagger.io/tools/swagger-ui/[Swagger UI]
+* https://swagger.io/tools/swagger-inspector/[Swagger Inspector]
+* https://swagger.io/tools/swagger-codegen/[Swagger Codegen]
+* https://www.postman.com/[Postman]
+
 == Generic Swagger Documentation
 
-== Project specific Swagger Documentation
+The generic Swagger documentation contains descriptions for all endpoints the REST API provides. In particular, it contains API descriptions for the following parts:
+
+* Authentication
+* Entities API
+* Files API
+* Messages API
+* User Session API
+
+The Generic Swagger Documentation is available in the formats `JSON` and `YAML`:
+
+`/docs/swagger.yaml`:: YAML version of generic documentation.
+`/docs/swagger.json`:: JSON version of generic documentation.
+
+TIP: It is also available online at http://files.cuba-platform.com/swagger/7.2
+
+== Project-specific Swagger Documentation
+
+Any running Jmix application also automatically generated project-specific documentation. Project-specific means that it contains documentation not only about the standard APIs that part of Jmix, but also about your project-specific entities, like `sample_Customer`, `sample_Order`, etc.
+
+The project-specific Swagger Documentation is available in the formats `JSON` and `YAML`:
+
+`/docs/swaggerDetailed.yaml`:: YAML version of project-specific Swagger documentation.
+`/docs/swaggerDetailed.json`:: JSON version of project-specific Swagger documentation.

--- a/content/modules/rest/pages/api-docs.adoc
+++ b/content/modules/rest/pages/api-docs.adoc
@@ -2,7 +2,7 @@
 
 The generic REST API provides automatically generated API documentation through Swagger 2.0.
 
-You can use the API documentation to visualize, test, or generate a client code for the REST API. There are various tools that allow to use this documentation to provide those capabilities like:
+You can use the API documentation to visualize, test, or generate a client code for the REST API. There are various tools that allow you to use this documentation to provide those capabilities like:
 
 * https://swagger.io/tools/swagger-ui/[Swagger UI]
 * https://swagger.io/tools/swagger-inspector/[Swagger Inspector]
@@ -19,7 +19,7 @@ The generic Swagger documentation contains descriptions for all endpoints the RE
 * Messages API
 * User Session API
 
-The Generic Swagger Documentation is available in the formats `JSON` and `YAML`:
+The Generic Swagger Documentation is available in `JSON` and `YAML` formats:
 
 `/docs/swagger.yaml`:: YAML version of generic documentation.
 `/docs/swagger.json`:: JSON version of generic documentation.
@@ -28,7 +28,7 @@ TIP: It is also available online at http://files.cuba-platform.com/swagger/7.2
 
 == Project-specific Swagger Documentation
 
-Any running Jmix application also automatically generated project-specific documentation. Project-specific means that it contains documentation not only about the standard APIs that part of Jmix, but also about your project-specific entities, like `sample_Customer`, `sample_Order`, etc.
+Any running Jmix application also automatically generates project-specific documentation. Project-specific means that it contains documentation not only about the standard APIs that part of Jmix, but also about your project-specific entities, like `sample_Customer`, `sample_Order`, etc.
 
 The project-specific Swagger Documentation is available in the formats `JSON` and `YAML`:
 

--- a/content/modules/rest/pages/entities-api/load-entities.adoc
+++ b/content/modules/rest/pages/entities-api/load-entities.adoc
@@ -13,7 +13,7 @@ The Entities API allows you to load entities through the API in various ways:
 
 == Load Entity by ID
 
-The first way of loading an entity via the Entities API is by loading it via its ID. The corresponding endpoint for this is the Load Entity endpoint `entities/:entityName/:entityId`.
+The first way of loading an entity via the Entities API is by loading it via its ID. The corresponding endpoint for this is the Load Entity endpoint `/entities/:entityName/:entityId`.
 
 The `:entityName` path parameter defines which entity type it is. The value is defined in the entity definition:
 


### PR DESCRIPTION
This PR contains:

* generic API description 
* project-specific API description

Right now it contains an old link to the hosted CUBA swagger UI, that we need to fix after Jmix has also a hosted variant.