### PR TITLE
Fix example code highlighter #162

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -39,3 +39,4 @@ asciidoc:
     jmix-plugin-site: 'https://plugins.jetbrains.com/plugin/14340-jmix/versions'
     page-pagination: true
     java_api_url: 'https://docs.jmix.io/api'
+    

--- a/content/supplemental/partials/footer-scripts.hbs
+++ b/content/supplemental/partials/footer-scripts.hbs
@@ -2,13 +2,19 @@
 {{! License, v. 2.0. If a copy of the MPL was not distributed with this }}
 {{! file, You can obtain one at http://mozilla.org/MPL/2.0/. }}
 <script src="{{{uiRootPath}}}/js/site.js"></script>
-<script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-<script type="text/javascript"> docsearch({
-    apiKey: 'a5ed07e1d4c440ff5b153e5c45cfce5f',
-    appId: '7T46OAMHYZ',
-    indexName: 'prod_jmixdocsen',
-    inputSelector: '#search-input', // DocSearch will add a search dropdown to an element with this CSS selector
-    debug: false // Set debug to true if you want to inspect the dropdown
-});
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"
+></script>
+<script>
+  hljs.highlightAll();
+</script>
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+></script>
+<script type="text/javascript">
+  docsearch({ apiKey: 'a5ed07e1d4c440ff5b153e5c45cfce5f', appId: '7T46OAMHYZ',
+  indexName: 'prod_jmixdocsen', inputSelector: '#search-input', // DocSearch
+  will add a search dropdown to an element with this CSS selector debug: false
+  // Set debug to true if you want to inspect the dropdown });
 </script>

--- a/content/supplemental/partials/head-styles.hbs
+++ b/content/supplemental/partials/head-styles.hbs
@@ -3,3 +3,4 @@
 {{! file, You can obtain one at http://mozilla.org/MPL/2.0/. }}
 <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/default.min.css">


### PR DESCRIPTION
[Fix example code highlighter #162](https://app.zenhub.com/workspaces/jmix-docs-60388fb6aecedc001c30e0e7/issues/haulmont/jmix-docs/162)

Updated highlight.js