### PR TITLE
Wrong code tag included in 'Opening Screens'

### DIFF
--- a/content/modules/backoffice-ui/pages/opening-screens.adoc
+++ b/content/modules/backoffice-ui/pages/opening-screens.adoc
@@ -191,7 +191,7 @@ When using `ScreenBuilders`, the listener can be provided in the `withAfterClose
 
 [source,java,indent=0]
 ----
-include::example$/ex1/src/main/java/ui/ex1/screen/screens/open/ShowScreens3.java[tags=screens;notifications;show-other-screen]
+include::example$/ex1/src/main/java/ui/ex1/screen/screens/open/ShowScreens3.java[tags=screen-builders;notifications;show-other-screen]
 ----
 
 The event object provides information about how the screen was closed. This information can be obtained in two ways: 


### PR DESCRIPTION
Wrong include tag in Backoffice UI > Opening Screens > Executing Code after Close and Returning Values
('screens' instead of 'screen-builders')

Mistake output in rendered content:

When using ScreenBuilders, the listener can be provided in the withAfterCloseListener() method:

@Autowired
private Screens screens;

@Autowired
private Notifications notifications;

private void openOtherScreen() {
    screenBuilders.screen(this)
       ...