### PR TITLE
Fix :  java code exemple image used for XML case

### DIFF
--- a/content/modules/flow-ui/pages/vc/components/avatar.adoc
+++ b/content/modules/flow-ui/pages/vc/components/avatar.adoc
@@ -64,7 +64,7 @@ Similarly, an image can be loaded from an arbitrary URL.
 +
 [source, xml, indent=0]
 ----
-include::example$onboarding/src/main/java/com/company/onboarding/view/component/avatar/AvatarView.java[tags=url-image]
+include::example$onboarding/src/main/java/com/company/onboarding/view/component/avatar/avatar-view.xml[tags=url-image]
 ----
 
 * In Java:


### PR DESCRIPTION
In the documentation, java code exemple image used for XML case in the section "URL Image" for avatar doc.