### PR TITLE
Update getting-started.adoc adding notes to a request

### DIFF
--- a/content/modules/rest/pages/getting-started.adoc
+++ b/content/modules/rest/pages/getting-started.adoc
@@ -92,6 +92,9 @@ With the access token you can use the generic REST API endpoints to load a list 
 curl -X GET http://localhost:8080/rest/entities/User \
     -H "Authorization: Bearer <access_token>"
 ----
+N.B.: if your project has a Project Id (a prefix, that is added to entities, tables and bean names), it should be added to a request as `<project-id>_User`.
+
+FYI: here `-X GET` key is added explicitly to show the type of it. cURL will note you about unnecessary use of `-X`, `GET` is already inferred.
 
 The response will contain all users that are available in the application:
 


### PR DESCRIPTION
In an example of Jmix docs there are requests, that return user information. A cURL sample is given as follows
```
curl -X GET http://localhost:8080/rest/entities/User -H "Authorization: Bearer <access_token>"   
```
where `-X` key **should be** omitted in request, and project **prefix added** to an entity name
```
curl http://localhost:8080/rest/entities/smp_User -H "Authorization: Bearer <access_token>"   
```