### PR TITLE
Add note about driverDelegateClass property to Quartz documentation 931

### DIFF
--- a/content/modules/quartz/pages/index.adoc
+++ b/content/modules/quartz/pages/index.adoc
@@ -21,6 +21,22 @@ implementation 'io.jmix.quartz:jmix-quartz-starter'
 implementation 'io.jmix.quartz:jmix-quartz-flowui-starter'
 ----
 
+[NOTE]
+====
+If URL of your main database is set as variable replacing the whole URL (e.g. `main.datasource.url = $\{DB_URL\}`)
+you may need to explicitly set the proper driver delegate class via `spring.quartz.properties.org.quartz.jobStore.driverDelegateClass` application property.
+
+Value depends on your database:
+
+* *PostgreSQL*: `org.quartz.impl.jdbcjobstore.PostgreSQLDelegate`
+* *Oracle*: `org.quartz.impl.jdbcjobstore.oracle.OracleDelegate`
+* *MS SQL*: `org.quartz.impl.jdbcjobstore.MSSQLDelegate`
+* Other database: skip this step - default value will be used
+
+If variable within `main.datasource.url` property doesn't include database prefix (e.g. `main.datasource.url = jdbc:postgresql://$\{DB_HOST\}/$\{DB_NAME\}`)
+or there are no variables at all - driver delegate class will be resolved automatically and this step can be skipped.
+====
+
 // todo flowui
 // [source,groovy,indent=0]
 // ----


### PR DESCRIPTION
See [Quartz doesn't set correct driver delegate class while main datastore url is set via variable #3970](https://github.com/jmix-framework/jmix/issues/3970)